### PR TITLE
Fix JReleaser tag-based versioning for v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           ./gradlew jacocoTestReport jacocoTestCoverageVerification
 
       - name: Stage artifacts to Maven Central Portal
-        run: ./gradlew publishMavenJavaPublicationToStagingRepository
+        run: ./gradlew publishMavenJavaPublicationToStagingRepository -Pversion=${{ steps.version.outputs.version }}
         env:
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
           JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
@@ -62,7 +62,7 @@ jobs:
           JRELEASER_NEXUS2_PASSWORD: ${{ secrets.JRELEASER_NEXUS2_PASSWORD }}
 
       - name: Create GitHub Release with JReleaser
-        run: ./gradlew jreleaserFullRelease
+        run: ./gradlew jreleaserFullRelease -Pversion=${{ steps.version.outputs.version }}
         env:
           JRELEASER_GITHUB_TOKEN: ${{ secrets.JRELEASER_GITHUB_TOKEN }}
           JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}


### PR DESCRIPTION
## Summary
Enable proper Git tag-based versioning for JReleaser to fix v0.1.0 release deployment.

## Problem
JReleaser was using `0.1.0-SNAPSHOT` from gradle.properties instead of the Git tag `v0.1.0`, causing releases to be deployed to SNAPSHOT repository instead of Maven Central Portal.

## Changes Made
- **GitHub Actions**: Pass `-Pversion=${{ steps.version.outputs.version }}` to both staging and JReleaser commands
- **Remove invalid config**: Remove unsupported `model:` section from jreleaser.yml that was causing parsing errors

## Testing Results ✅
Local test with `./gradlew jreleaserConfig -Pversion=0.1.0`:
- ✅ Project version: `0.1.0` (not SNAPSHOT)
- ✅ Release is not snapshot: `true`  
- ✅ Maven Central deployer: `mavenCentral.release-deploy` active
- ✅ Artifact paths: `proto-faker-0.1.0.jar` (correct version)

## Impact
This fixes the final blocker for the v0.1.0 release. After merge, the GitHub Actions workflow will properly deploy production releases to Maven Central Portal instead of SNAPSHOT repository.

🤖 Generated with [Claude Code](https://claude.ai/code)